### PR TITLE
Add module for python virtualenv

### DIFF
--- a/modules.go
+++ b/modules.go
@@ -28,6 +28,8 @@ func handleModule(module string, segment *Segment, args []string) {
 		envSegment(segment, args)
 	case "plugin":
 		pluginSegment(segment, args)
+	case "virtualenv":
+		virtualEnvSegment(segment)
 	default:
 		dief("invalid module: %q", module)
 	}

--- a/virtualenv.go
+++ b/virtualenv.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+	"path"
+	. "github.com/reujab/bronze/types"
+)
+
+func virtualEnvSegment(segment *Segment) {
+	content := os.Getenv("VIRTUAL_ENV")
+	if (content != "") {
+		segment.Value = path.Base(content)
+	}
+}


### PR DESCRIPTION
Shows the name of the directory where the active virtualenv is:
![image](https://user-images.githubusercontent.com/2236848/38480101-13ae9964-3b89-11e8-8ce2-6cd8469e32b6.png)

It searches for the $VIRTUAL_ENV variable. It could be done using the env segment, but if the directory had many parents it could appear very long, this segment shows only the deepest directory in the path. Another option could be to add one more parameter to the env segment as a flag to shorten the content of the variable.